### PR TITLE
fix(DateTimeUtils): convert precision of `fromTimestamp` should be nanoseconds

### DIFF
--- a/kun-workflow/kun-workflow-utils/src/main/java/com/miotech/kun/workflow/utils/DateTimeUtils.java
+++ b/kun-workflow/kun-workflow-utils/src/main/java/com/miotech/kun/workflow/utils/DateTimeUtils.java
@@ -56,11 +56,25 @@ public class DateTimeUtils {
         return OffsetDateTime.now(globalClock);
     }
 
+    /**
+     * Converts a {@link java.sql.Timestamp Timestamp} object to {@link java.time.OffsetDateTime OffsetDatetime} object
+     * at nanosecond-level precision.
+     * @param timestamp the {@link java.sql.Timestamp Timestamp} object to transform
+     * @return converted {@link java.time.OffsetDateTime OffsetDatetime} object
+     */
     public static OffsetDateTime fromTimestamp(Timestamp timestamp) {
         if (timestamp == null) return null;
-        return OffsetDateTime.ofInstant(
+        OffsetDateTime parsedOffsetDatetime = OffsetDateTime.ofInstant(
                 Instant.ofEpochMilli(timestamp.getTime()),
                 ZoneId.systemDefault());
+        /**
+        * Fix: OffsetDatetime object from <code>Instant.ofEpochMilli(timestamp.getTime())</code>
+        * can only provide millisecond precision transformation. The following line fixes this issue and provides
+        * nanoseconds precision conversion.
+        */
+        return parsedOffsetDatetime
+                .minusNanos(parsedOffsetDatetime.getNano())
+                .plusNanos(timestamp.getNanos());
     }
 
     /**

--- a/kun-workflow/kun-workflow-utils/src/test/java/com/miotech/kun/workflow/utils/DateTimeUtilsTest.java
+++ b/kun-workflow/kun-workflow-utils/src/test/java/com/miotech/kun/workflow/utils/DateTimeUtilsTest.java
@@ -2,6 +2,7 @@ package com.miotech.kun.workflow.utils;
 
 import org.junit.Test;
 
+import java.sql.Timestamp;
 import java.time.OffsetDateTime;
 
 import static org.hamcrest.Matchers.is;
@@ -24,5 +25,18 @@ public class DateTimeUtilsTest {
 
         // teardown
         DateTimeUtils.resetClock();
+    }
+
+    @Test
+    public void fromTimestamp_withValidTimestampObject_shouldConvertAtNanosecondsPrecision() {
+        Timestamp timestamp = Timestamp.valueOf("2020-09-02 21:41:17.903664124");
+        OffsetDateTime convertedDatetime = DateTimeUtils.fromTimestamp(timestamp);
+        assertThat(convertedDatetime.getYear(), is(2020));
+        assertThat(convertedDatetime.getMonthValue(), is(9));
+        assertThat(convertedDatetime.getDayOfMonth(), is(2));
+        assertThat(convertedDatetime.getHour(), is(21));
+        assertThat(convertedDatetime.getMinute(), is(41));
+        assertThat(convertedDatetime.getSecond(), is(17));
+        assertThat(convertedDatetime.getNano(), is(903664124));
     }
 }


### PR DESCRIPTION
see the issue https://github.com/miotech/KUN/issues/22 for details

Closes #22 