### PR TITLE
chore: add "gradle.properties" for project build configuration

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,7 @@
+# Project-wide Gradle settings.
+
+# Specifies the JVM arguments used for the daemon process.
+# The org.gradle.jvmargs Gradle property controls the VM running the build.
+# It defaults to -Xmx512m "-XX:MaxMetaspaceSize=256m"
+# Reference: https://docs.gradle.org/6.3/userguide/build_environment.html#sec:configuring_jvm_memory
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -XX:MaxJavaStackTraceDepth=100000 -Dfile.encoding=UTF-8


### PR DESCRIPTION
Fixes gradle out of heap memory problem in some cases