### PR TITLE
fix(task-definition-service): should update deployed task name columns after updating original task definition name

### DIFF
--- a/kun-data-platform/kun-data-platform-web/src/main/java/com/miotech/kun/dataplatform/common/deploy/dao/DeployedTaskDao.java
+++ b/kun-data-platform/kun-data-platform-web/src/main/java/com/miotech/kun/dataplatform/common/deploy/dao/DeployedTaskDao.java
@@ -57,6 +57,11 @@ public class DeployedTaskDao {
     }
 
     public Optional<DeployedTask> fetchById(Long definitionId) {
+        // SELECT taskcommit.id AS taskcommit_id, taskcommit.task_def_id AS taskcommit_task_def_id, taskcommit.version AS taskcommit_version, taskcommit.message AS taskcommit_message, taskcommit.snapshot AS taskcommit_snapshot, taskcommit.committer AS taskcommit_committer, taskcommit.committed_at AS taskcommit_committed_at, taskcommit.commit_type AS taskcommit_commit_type, taskcommit.commit_status AS taskcommit_commit_status, taskcommit.is_latest AS taskcommit_is_latest, deployedtask.id AS deployedtask_id, deployedtask.definition_id AS deployedtask_definition_id, deployedtask.name AS deployedtask_name, deployedtask.task_template_name AS deployedtask_task_template_name, deployedtask.wf_task_id AS deployedtask_wf_task_id, deployedtask.owner AS deployedtask_owner, deployedtask.commit_id AS deployedtask_commit_id, deployedtask.is_archived AS deployedtask_is_archived
+        // FROM kun_dp_deployed_task AS deployedtask
+        // INNER JOIN kun_dp_task_commit AS taskcommit
+        // ON deployedtask.commit_id = taskcommit.id
+        // WHERE deployedtask.definition_id= ?
         String sql = getSelectSQL(String.format(" %s.%s= ?", DEPLOYED_TASK_MODEL_NAME, DEFINITION_ID));
         List<DeployedTask> deployedTasks = jdbcTemplate.query(sql, DeployedTaskMapper.INSTANCE, definitionId);
         return deployedTasks.stream().findAny();

--- a/kun-data-platform/kun-data-platform-web/src/test/java/com/miotech/kun/dataplatform/TestWorkflowConfig.java
+++ b/kun-data-platform/kun-data-platform-web/src/test/java/com/miotech/kun/dataplatform/TestWorkflowConfig.java
@@ -4,8 +4,10 @@ import com.google.common.collect.Lists;
 import com.miotech.kun.workflow.client.WorkflowClient;
 import com.miotech.kun.workflow.client.model.ConfigKey;
 import com.miotech.kun.workflow.client.model.Operator;
+import com.miotech.kun.workflow.client.model.Task;
 import com.miotech.kun.workflow.client.operator.OperatorUpload;
 import com.miotech.kun.workflow.core.execution.ConfigDef;
+import com.miotech.kun.workflow.core.model.common.Tag;
 import com.miotech.kun.workflow.utils.WorkflowIdGenerator;
 import org.mockito.Mockito;
 import org.springframework.context.annotation.Bean;
@@ -16,6 +18,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 
 @Configuration
@@ -47,6 +50,15 @@ public class TestWorkflowConfig {
         doReturn(Optional.of(getMockOperator())).when(mockClient).getOperator(anyString());
 
         doReturn(getMockOperator()).when(mockClient).getOperator(anyLong());
+
+        doAnswer((invocation) -> {
+            Task task = invocation.getArgument(0);
+            List<Tag> filterTags = invocation.getArgument(1);
+            return task.cloneBuilder()
+                    .withId(task.getId() == null ? WorkflowIdGenerator.nextTaskId() : task.getId())
+                    .withTags(filterTags)
+                    .build();
+        }).when(mockClient).saveTask(any(), any());
 
         return mockClient;
     }


### PR DESCRIPTION
Closese #357 