### PR TITLE
improve DAG speed

### DIFF
--- a/kun-workflow/kun-workflow-common/src/main/java/com/miotech/kun/workflow/common/taskrun/service/TaskRunService.java
+++ b/kun-workflow/kun-workflow-common/src/main/java/com/miotech/kun/workflow/common/taskrun/service/TaskRunService.java
@@ -235,7 +235,7 @@ public class TaskRunService {
         }
 
         List<TaskRunVO> nodes = result.stream()
-                .map(this::convertToVO)
+                .map(this::convertToVOWithoutAttempt)
                 .collect(Collectors.toList());
         List<TaskRunDependencyVO> edges = result.stream()
                 .flatMap(x -> x.getDependentTaskRunIds().stream()
@@ -296,6 +296,13 @@ public class TaskRunService {
 
         return taskRuns.stream().map(taskRun ->
                 buildTaskRunVO(taskRun, taskAttemptPropsMap.get(taskRun.getId()), new ArrayList<>())).collect(Collectors.toList());
+    }
+
+    public TaskRunVO convertToVOWithoutAttempt(TaskRun taskRun) {
+        List<TaskRun> failedUpstreamTaskRuns = taskRun.getStatus().isUpstreamFailed() ?
+                taskRunDao.fetchFailedUpstreamTaskRuns(taskRun.getId()) : Collections.emptyList();
+        logger.debug("ConvertToVO: failed upstream task runs {}", failedUpstreamTaskRuns.toString());
+        return buildTaskRunVO(taskRun, Collections.emptyList(), failedUpstreamTaskRuns);
     }
 
     public TaskRunVO convertToVO(TaskRun taskRun) {


### PR DESCRIPTION
1. 修改一个获取TaskRuns的for循环为一次fetchAll（速度提升有限）
2. 构建DAG的node获取TaskRunVO时，不再获取前端不需要的TaskAttempt（速度提升较多）